### PR TITLE
Add Debian Dockerfile

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -7,11 +7,10 @@ EXPOSE 8000
 RUN apt-get update && apt-get install -y \
     chromium-driver
 
-# upgrade pip
-RUN pip install --upgrade pip
-
-# install selenium
-RUN pip install selenium
+# upgrade pip and install requirements.txt
+ADD requirements.txt .
+RUN pip install --upgrade pip \
+ && pip install -r requirements.txt
 
 # add the script to where selenium is installed
 ADD main.py /usr/local/lib/python3.7/site-packages

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,23 @@
+FROM python:3.7-slim-buster
+
+# expose port
+EXPOSE 8000
+
+# install chromedriver
+RUN apt-get update && apt-get install -y \
+    chromium-driver
+
+# upgrade pip
+RUN pip install --upgrade pip
+
+# install selenium
+RUN pip install selenium
+
+# add the script to where selenium is installed
+ADD main.py /usr/local/lib/python3.7/site-packages
+
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+USER appuser
+
+# run the script
+CMD [ "python3.7", "/usr/local/lib/python3.7/site-packages/main.py"]


### PR DESCRIPTION
Even though we're running in Docker, the ChromeDriver on Alpine had issues running on my Unraid (Slackware) server, throwing the error:
```
[1579573867.589][INFO]: RESPONSE InitSession unknown error: Chrome failed to start: crashed
  (unknown error: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /usr/lib/chromium/chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
```

I ended up making a Debian-based image as a last ditch effort and it actually worked for some reason. This is just an alternative option for anyone running into the obscure ChromeDriver/Alpine bug.