### PR TITLE
Update Alpine to bump Chromium to 79.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM python:3.7-alpine3.8
+FROM python:3.7-alpine3.11
 
 # expose port
 EXPOSE 8000
 
 # update apk repo
-RUN echo "http://dl-4.alpinelinux.org/alpine/v3.8/main" >> /etc/apk/repositories && \
-    echo "http://dl-4.alpinelinux.org/alpine/v3.8/community" >> /etc/apk/repositories
+RUN echo "http://dl-4.alpinelinux.org/alpine/v3.11/main" >> /etc/apk/repositories && \
+    echo "http://dl-4.alpinelinux.org/alpine/v3.11/community" >> /etc/apk/repositories
 
 # install chromedriver
 RUN apk update \


### PR DESCRIPTION
Fixes #9 

Bumps Alpine from 3.8 to 3.11 and Chromium from 68 to 79. Fixes the `Chrome failed to start: crashed (unknown error: DevToolsActivePort file doesn't exist)` error for some reason.